### PR TITLE
Fix the name of the milestones repo: 'dcppc-milestones' not 'milestones'

### DIFF
--- a/config_centillion.json
+++ b/config_centillion.json
@@ -9,7 +9,7 @@
         "dcppc/markdown-issues",
         "dcppc/design-guidelines-discuss",
         "dcppc/dcppc-deliverables",
-        "dcppc/milestones",
+        "dcppc/dcppc-milestones",
         "dcppc/crosscut-metadata",
         "dcppc/lucky-penny",
         "dcppc/dcppc-workshops",


### PR DESCRIPTION
Yup just take a gander at the title there, no description needed, this portion is really not necessary, since everything is explained in the title, and you can probably just move your eyeballs just a tiny little bit to read that title up there, yep, that will take care of the whole question of what this PR is doing, no "description" or complicated fancy markup, just a plain ol sentence, right there in the title, in big ol fancy font even, just take a gander there