### PR TITLE
remove button for non-functional endpoint

### DIFF
--- a/templates/controlpanel.html
+++ b/templates/controlpanel.html
@@ -77,6 +77,7 @@
         </div>
 
         {# update diff search index #}
+        {#
         <div class="panel panel-danger">
             <div class="panel-heading">
                 <h3 class="panel-title">
@@ -98,7 +99,7 @@
 
             </div>
         </div>
-
+        #}
 
     </div>
 


### PR DESCRIPTION
removes (from the control panel) the button to build the "diff" search index, as opposed to rebuilding the search index from scratch.

we'll get to the diff search index stuff eventually, but not a high priority. indexing from scratch goes pretty fast.