### PR TITLE
add created/modified date to google drive/gh issues master lists

### DIFF
--- a/centillion_search.py
+++ b/centillion_search.py
@@ -17,6 +17,7 @@ import pypandoc
 import os.path
 import codecs
 from datetime import datetime
+import dateutil.parser
 
 from whoosh.qparser import MultifieldParser, QueryParser
 from whoosh.analysis import StemmingAnalyzer
@@ -1079,11 +1080,11 @@ class Search:
         # in the everything-list.
         item_keys=''
         if doctype=='gdoc':
-            item_keys = ['title','owner_name','url','mimetype']
+            item_keys = ['title','owner_name','url','mimetype','created_time','modified_time']
+        elif doctype=='issue':
+            item_keys = ['title','repo_name','repo_url','url','created_time','modified_time']
         elif doctype=='emailthread':
             item_keys = ['title','owner_name','url']
-        elif doctype=='issue':
-            item_keys = ['title','repo_name','repo_url','url']
         elif doctype=='ghfile':
             item_keys = ['title','repo_name','repo_url','url']
         elif doctype=='markdown':
@@ -1100,7 +1101,11 @@ class Search:
             for r in results:
                 d = {}
                 for k in item_keys:
-                    d[k] = r[k]
+                    if k=='created_time' or k=='modified_time':
+                        #d[k] = r[k]
+                        d[k] = dateutil.parser.parse(r[k]).strftime("%Y-%m-%d")
+                    else:
+                        d[k] = r[k]
                 json_results.append(d)
 
         return json_results

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests>=2.19
 pandoc>=1.0
 flask-dance>=1.0.0
 beautifulsoup4>=4.6
+python-dateutil>=2.6

--- a/static/centillion_master_list.js
+++ b/static/centillion_master_list.js
@@ -79,9 +79,11 @@ function load_gdoc_table(){
             var r = new Array(), j = -1, size=result.length;
             r[++j] = '<thead>'
             r[++j] = '<tr class="header-row">';
-            r[++j] = '<th width="50%">File Name</th>';
-            r[++j] = '<th width="30%">Owner</th>';
-            r[++j] = '<th width="20%">Type</th>';
+            r[++j] = '<th width="40%">File Name</th>';
+            r[++j] = '<th width="15%">Owner</th>';
+            r[++j] = '<th width="15%">Type</th>';
+            r[++j] = '<th width="15%">Created</th>';
+            r[++j] = '<th width="15%">Modified</th>';
             r[++j] = '</tr>';
             r[++j] = '</thead>'
             r[++j] = '<tbody>'
@@ -94,6 +96,10 @@ function load_gdoc_table(){
                 r[++j] = result[i]['owner_name'];
                 r[++j] = '</td><td>';
                 r[++j] = result[i]['mimetype'];
+                r[++j] = '</td><td>';
+                r[++j] = result[i]['created_time'];
+                r[++j] = '</td><td>';
+                r[++j] = result[i]['modified_time'];
                 r[++j] = '</td></tr>';
             }
             r[++j] = '</tbody>'
@@ -121,8 +127,10 @@ function load_issue_table(){
             var r = new Array(), j = -1, size=result.length;
             r[++j] = '<thead>'
             r[++j] = '<tr class="header-row">';
-            r[++j] = '<th width="70%">Issue Name</th>';
-            r[++j] = '<th width="30%">Repository</th>';
+            r[++j] = '<th>Issue Name</th>';
+            r[++j] = '<th width="15%">Repository</th>';
+            r[++j] = '<th width="15%">Created</th>';
+            r[++j] = '<th width="15%">Modified</th>';
             r[++j] = '</tr>';
             r[++j] = '</thead>'
             r[++j] = '<tbody>'
@@ -135,6 +143,10 @@ function load_issue_table(){
                 r[++j] = '<a href="' + result[i]['repo_url'] + '" target="_blank">'
                 r[++j] = result[i]['repo_name'];
                 r[++j] = '</a>'
+                r[++j] = '</td><td>';
+                r[++j] = result[i]['created_time'];
+                r[++j] = '</td><td>';
+                r[++j] = result[i]['modified_time'];
                 r[++j] = '</td></tr>';
             }
             r[++j] = '</tbody>'


### PR DESCRIPTION
Add created/modified date to the Google Drive and Github Issues master lists

Screenshot sorting Google Drive documents by modified date:

<img width="1244" alt="screen shot 2018-08-15 at 00 23 05" src="https://user-images.githubusercontent.com/368075/44136928-7038f356-a023-11e8-8465-9027d6829887.png">

We have the full timestamp, but I'm truncating it to a date because it looks cleaner and it's easier to sort.