### PR TITLE
add option to set port at runtime

### DIFF
--- a/centillion.py
+++ b/centillion.py
@@ -294,5 +294,10 @@ def store_search(query, fields):
 if __name__ == '__main__':
     # if running local instance, set to true
     os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = 'true'
-    app.run(host="0.0.0.0",port=5000)
+    port = os.environ.get('CENTILLION_PORT','')
+    if port=='':
+        port = 5000
+    else:
+        port = int(port)
+    app.run(host="0.0.0.0",port=port)
 


### PR DESCRIPTION
use `CENTILLION_PORT` environment variable to set the port at runtime 

useful for the sandbox instance of centillion, which must run on a port other than 5000, so we don't have to edit the source code and worry about accidentally committing a different port number into centillion.py.

Not that I've _ever_ done _anything_ like that before.