### PR TITLE
Add dates and mailing list names to search results

### DIFF
--- a/centillion_search.py
+++ b/centillion_search.py
@@ -1165,9 +1165,9 @@ class Search:
             sr.id = r['id']
             sr.kind = r['kind']
 
-            sr.created_time = r['created_time']
-            sr.modified_time = r['modified_time']
-            sr.indexed_time = r['indexed_time']
+            sr.created_time =  datetime.strftime(r['created_time'],  "%Y-%m-%d %I:%M %p")
+            sr.modified_time = datetime.strftime(r['modified_time'], "%Y-%m-%d %I:%M %p")
+            sr.indexed_time =  datetime.strftime(r['indexed_time'],  "%Y-%m-%d %I:%M %p")
 
             sr.title = r['title']
             sr.url = r['url']
@@ -1176,6 +1176,8 @@ class Search:
 
             sr.owner_email = r['owner_email']
             sr.owner_name = r['owner_name']
+
+            sr.group = r['group']
 
             sr.repo_name = r['repo_name']
             sr.repo_url = r['repo_url']

--- a/templates/search.html
+++ b/templates/search.html
@@ -165,10 +165,18 @@
                                                 <a href='{{e.url}}'>{{e.title}}</a>
                                                 (Owner: {{e.owner_name}}, {{e.owner_email}})<br />
                                                 <b>Document Type</b>: {{e.mimetype}}
+                                                {% if e.created_time %} 
+                                                    <br/>
+                                                    <b>Created:</b> {{e.created_time}}
+                                                {% endif %}
                                             {% else %}
                                                 <b>Google Drive File:</b>
                                                 <a href='{{e.url}}'>{{e.title}}</a><br />
                                                 <b>Owner:</b> {{e.owner_name}}, {{e.owner_email}}<br />
+                                                {% if e.created_time %} 
+                                                    <br/>
+                                                    <b>Created:</b> {{e.created_time}}
+                                                {% endif %}
                                             {% endif %}
 
                                         {% elif e.kind=="issue" %}
@@ -179,6 +187,10 @@
                                             {% endif %}
                                             <br/>
                                             <b>Repository:</b> <a href='{{e.repo_url}}'>{{e.repo_name}}</a>
+                                            {% if e.created_time %} 
+                                                <br/>
+                                                <b>Date:</b> {{e.created_time}}
+                                            {% endif %}
 
                                         {% elif e.kind=="ghfile" %}
                                             <b>Github File:</b>
@@ -197,6 +209,21 @@
                                             <a href='{{e.url}}'>{{e.title}}</a>
                                             <br/>
                                             <b>Started By:</b> {{e.owner_name}}
+                                            <br/>
+                                            <b>Mailing List:</b> {{e.group}}
+                                            {% if e.created_time %} 
+                                                <br/>
+                                                <b>Date:</b> {{e.created_time}}
+                                            {% endif %}
+
+                                        {% elif e.kind=="disqus" %}
+                                            <b>Disqus Comment Thread:</b>
+                                            <a href='{{e.url}}'>{{e.title}}</a>
+                                            <br/>
+                                            {% if e.created_time %} 
+                                                <br/>
+                                                <b>Date:</b> {{e.created_time}}
+                                            {% endif %}
 
                                         {% else %}
                                             <b>Item:</b> (<a href='{{e.url}}'>link</a>)


### PR DESCRIPTION
We added dates and mailing list names to the master list table, but forgot to add them to the search results table!

The result looks a lot better - now it's _much_ easier to put each email thread into context.

<img width="1212" alt="screen shot 2018-08-24 at 09 38 04" src="https://user-images.githubusercontent.com/368075/44596557-75932f00-a781-11e8-8c9e-36920f59ffea.png">
