### PR TITLE
fix github file/folder linking

### DIFF
--- a/centillion_search.py
+++ b/centillion_search.py
@@ -559,6 +559,15 @@ class Search:
 
             key = fname+"_"+fsha
 
+            if d['type'] == 'blob':
+                usable_url = "https://github.com/%s/blob/master/%s"%(repo_name, fpath)
+
+            elif d['type'] == 'tree':
+                usable_url = "https://github.com/%s/tree/master/%s"%(repo_name, fpath)
+
+            else:
+                usable_url = repo_url
+
             # Now create the actual search index record
             try:
                 writer.add_document(
@@ -568,7 +577,7 @@ class Search:
                         modified_time = None,
                         indexed_time = indexed_time,
                         title = fname,
-                        url = repo_url,
+                        url = usable_url,
                         mimetype='',
                         owner_email='',
                         owner_name='',


### PR DESCRIPTION
This fixes how links to github files and folders are constructed. Files are blobs, folders are trees.

Tested locally with centillion localhost.

Closes #108 

- [x] Is this pull request mergeable?
- [x] Has this been tested locally?
- [ ] Does this pull request pass the tests?
- [ ] Have new tests been added to cover any new code?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?

