### PR TITLE
Hotfix for Groups.io problems

### DIFF
--- a/src/search/__init__.py
+++ b/src/search/__init__.py
@@ -160,15 +160,6 @@ class Search:
                 logging.exception(msg)
                 pass
 
-        # Groups.io email threads
-        if run_which=='all' or run_which=='emailthreads':
-            try:
-                self.update_index_emailthreads(groupsio_token, config)
-            except GroupsIOException as e:
-                msg = "ERROR: While re-indexing: failed to update Groups.io email threads. Continuing..."
-                logging.exception(msg)
-                pass
-
         # Github files
         if run_which=='all' or run_which=='ghfiles':
             try:
@@ -195,6 +186,16 @@ class Search:
                 msg = "ERROR: While re-indexing: failed to update Google Drive. Continuing..."
                 logging.exception(msg)
                 pass
+
+        # Groups.io email threads
+        if run_which=='all' or run_which=='emailthreads':
+            try:
+                self.update_index_emailthreads(groupsio_token, config)
+            except GroupsIOException as e:
+                msg = "ERROR: While re-indexing: failed to update Groups.io email threads. Continuing..."
+                logging.exception(msg)
+                pass
+
 
 
     # ------------------------------
@@ -968,8 +969,6 @@ class Search:
             # Stop early if testing
             if config['TESTING'] is True and k>=1:
                 break
-            if k>=15:
-                break
 
 
         writer = self.ix.writer()
@@ -1144,32 +1143,34 @@ class Search:
 
         archives = get_mbox_archives(groupsio_token,config)
 
-        writer = self.ix.writer()
-        count = 0
+        if archives not None:
 
-        # archives is a dictionary
-        # keys are IDs (urls)
-        # values are dictionaries
+            writer = self.ix.writer()
+            count = 0
 
-        # Start by collecting all the things
-        remote_ids = set()
-        for k in archives.keys():
-            remote_ids.add(k)
+            # archives is a dictionary
+            # keys are IDs (urls)
+            # values are dictionaries
 
-        # drop indexed_ids
-        for drop_id in indexed_ids:
-            writer.delete_by_term('id',drop_id)
+            # Start by collecting all the things
+            remote_ids = set()
+            for k in archives.keys():
+                remote_ids.add(k)
 
-        # add remote_ids
-        for add_id in remote_ids:
-            item = archives[add_id]
-            self.add_emailthread(writer, item, config, update=False)
-            count += 1
+            # drop indexed_ids
+            for drop_id in indexed_ids:
+                writer.delete_by_term('id',drop_id)
 
-        writer.commit()
+            # add remote_ids
+            for add_id in remote_ids:
+                item = archives[add_id]
+                self.add_emailthread(writer, item, config, update=False)
+                count += 1
 
-        msg = "Done, updated %d Groups.io email threads in the index" % count
-        logging.info(msg)
+            writer.commit()
+
+            msg = "Done, updated %d Groups.io email threads in the index" % count
+            logging.info(msg)
 
 
 

--- a/src/search/groupsio_util.py
+++ b/src/search/groupsio_util.py
@@ -48,11 +48,19 @@ def get_mbox_archives(groupsio_token,config):
 
         subgroup_name = subgroup_ids[subgroup_id]
 
-        # This function call below will call
-        # get_archive_zip for each subgroup,
-        # and extract the mbox contents from
-        # the zip file.
-        html = extract_mbox_from_zip(subgroup_name, subgroup_id, groupsio_token)
+        try:
+            # This function call below will call
+            # get_archive_zip for each subgroup,
+            # and extract the mbox contents from
+            # the zip file.
+            html = extract_mbox_from_zip(subgroup_name, subgroup_id, groupsio_token)
+            if html is None:
+                raise Exception("Could not extract mbox")
+
+        except:
+            logging.exception("FAILURE: Could not process mailbox for subgroup %s"%(subgroup_name))
+            # skip the rest and continue with the loop
+            continue
 
         # Now extract each email thread and 
         # add to final_archive dictionary


### PR DESCRIPTION
The Groups.io API shut off the `/downloadarchives` API endpoint. Unfortunately the Groups.io code was not robust enough to gracefully handle this, and all the Groups.io email threads in the search index were wiped out. -__-

This PR introduces a hotfix to handle the case of a failed mbox extraction so that we don't write empty records to the search index.